### PR TITLE
Refactor tests

### DIFF
--- a/tests/Manager/ModelListManagerTest.php
+++ b/tests/Manager/ModelListManagerTest.php
@@ -10,9 +10,9 @@ use FluxSE\OdooApiClient\Operations\Object\ExecuteKw\Options\SearchReadOptions;
 use FluxSE\OdooApiClient\Operations\Object\ExecuteKw\RecordListOperations;
 use FluxSE\OdooApiClient\Operations\Object\ExecuteKw\RecordListOperationsInterface;
 use PHPUnit\Framework\TestCase;
+use Tests\FluxSE\OdooApiClient\OdooVersionedClassProviderTrait;
 use Tests\FluxSE\OdooApiClient\Operations\CommonOperationsTrait;
 use Tests\FluxSE\OdooApiClient\Operations\Object\ExecuteKw\ExecuteKwOperationsTrait;
-use Tests\FluxSE\OdooApiClient\TestModel\OdooVersionedClassProviderTrait;
 
 class ModelListManagerTest extends TestCase
 {

--- a/tests/Manager/ModelListManagerTest.php
+++ b/tests/Manager/ModelListManagerTest.php
@@ -45,7 +45,7 @@ class ModelListManagerTest extends TestCase
 
     public function testFind(): void
     {
-        $partnerClass = $this->getPartnerClass();
+        $partnerClass = $this->getResPartnerClass();
         $searchReadOptions = new SearchReadOptions();
         $searchReadOptions->setLimit(1);
         $searchReadOptions->setOrder('id');
@@ -64,21 +64,21 @@ class ModelListManagerTest extends TestCase
 
     public function testFindByIds(): void
     {
-        $partnerClass = $this->getPartnerClass();
+        $partnerClass = $this->getResPartnerClass();
         $partners = $this->modelListManager->findByIds($partnerClass, [1]);
         self::assertContainsOnlyInstancesOf($partnerClass, $partners);
     }
 
     public function testFindOneBy(): void
     {
-        $partnerClass = $this->getPartnerClass();
+        $partnerClass = $this->getResPartnerClass();
         $partner = $this->modelListManager->findOneBy($partnerClass);
         self::assertInstanceOf($partnerClass, $partner);
     }
 
     public function testFindBy(): void
     {
-        $partnerClass = $this->getPartnerClass();
+        $partnerClass = $this->getResPartnerClass();
         $searchReadOptions = new SearchReadOptions();
         $searchReadOptions->setLimit(2);
 

--- a/tests/Manager/ModelListManagerTest.php
+++ b/tests/Manager/ModelListManagerTest.php
@@ -6,21 +6,19 @@ namespace Tests\FluxSE\OdooApiClient\Manager;
 
 use FluxSE\OdooApiClient\Manager\ModelListManager;
 use FluxSE\OdooApiClient\Manager\ModelListManagerInterface;
-use FluxSE\OdooApiClient\Model\BaseInterface;
 use FluxSE\OdooApiClient\Operations\Object\ExecuteKw\Options\SearchReadOptions;
 use FluxSE\OdooApiClient\Operations\Object\ExecuteKw\RecordListOperations;
 use FluxSE\OdooApiClient\Operations\Object\ExecuteKw\RecordListOperationsInterface;
 use PHPUnit\Framework\TestCase;
 use Tests\FluxSE\OdooApiClient\Operations\CommonOperationsTrait;
 use Tests\FluxSE\OdooApiClient\Operations\Object\ExecuteKw\ExecuteKwOperationsTrait;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Res\Partner as PartnerV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Res\Partner as PartnerV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Res\Partner as PartnerV19;
+use Tests\FluxSE\OdooApiClient\TestModel\OdooVersionedClassProviderTrait;
 
 class ModelListManagerTest extends TestCase
 {
     use ExecuteKwOperationsTrait,
-        CommonOperationsTrait;
+        CommonOperationsTrait,
+        OdooVersionedClassProviderTrait;
 
     private RecordListOperationsInterface $recordListOperations;
 
@@ -40,20 +38,9 @@ class ModelListManagerTest extends TestCase
         $this->odooVersion = $this->buildCommonOperations()->version()->getServerVersionInfo()[0];
     }
 
-    /**
-     * Get the appropriate Partner class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getPartnerClass(): string
+    protected function getOdooVersion(): int
     {
-        /** @var class-string<BaseInterface> $partnerClass */
-        $partnerClass = match (true) {
-            $this->odooVersion <= 17 => PartnerV17::class,
-            $this->odooVersion <= 18 => PartnerV18::class,
-            default => PartnerV19::class,
-        };
-
-        return $partnerClass;
+        return $this->odooVersion;
     }
 
     public function testFind(): void

--- a/tests/Manager/ModelManagerTest.php
+++ b/tests/Manager/ModelManagerTest.php
@@ -23,53 +23,13 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Tests\FluxSE\OdooApiClient\Operations\CommonOperationsTrait;
 use Tests\FluxSE\OdooApiClient\Operations\Object\ExecuteKw\ExecuteKwOperationsTrait;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Account\Account as AccountV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Account\Journal as JournalV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Account\Move as MoveV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Account\Move\Line as LineV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Account\Payment as PaymentV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Account\Payment\Method as MethodV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Account\Payment\Register as RegisterV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Account\Tax as TaxV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Product\Category as CategoryV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Product\Product as ProductV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Product\Template as TemplateV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Res\Currency as CurrencyV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Res\Partner as PartnerV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Uom\Uom as UomV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Account\Account as AccountV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Account\Journal as JournalV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Account\Move as MoveV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Account\Move\Line as LineV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Account\Payment as PaymentV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Account\Payment\Method as MethodV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Account\Payment\Register as RegisterV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Account\Tax as TaxV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Product\Category as CategoryV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Product\Product as ProductV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Product\Template as TemplateV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Res\Currency as CurrencyV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Res\Partner as PartnerV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Uom\Uom as UomV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Account\Account as AccountV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Account\Journal as JournalV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Account\Move as MoveV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Account\Move\Line as LineV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Account\Payment as PaymentV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Account\Payment\Method as MethodV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Account\Payment\Register as RegisterV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Account\Tax as TaxV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Product\Category as CategoryV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Product\Product as ProductV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Product\Template as TemplateV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Res\Currency as CurrencyV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Res\Partner as PartnerV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Uom\Uom as UomV19;
+use Tests\FluxSE\OdooApiClient\TestModel\OdooVersionedClassProviderTrait;
 
 class ModelManagerTest extends TestCase
 {
     use ExecuteKwOperationsTrait,
-        CommonOperationsTrait;
+        CommonOperationsTrait,
+        OdooVersionedClassProviderTrait;
 
     private RecordOperationsInterface $recordOperations;
 
@@ -97,228 +57,9 @@ class ModelManagerTest extends TestCase
         $this->odooVersion = $this->buildCommonOperations()->version()->getServerVersionInfo()[0];
     }
 
-    /**
-     * Get the appropriate Partner class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getPartnerClass(): string
+    protected function getOdooVersion(): int
     {
-        /** @var class-string<BaseInterface> $partnerClass */
-        $partnerClass = match (true) {
-            $this->odooVersion <= 17 => PartnerV17::class,
-            $this->odooVersion <= 18 => PartnerV18::class,
-            default => PartnerV19::class,
-        };
-
-        return $partnerClass;
-    }
-
-    /**
-     * Get the appropriate Account class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getAccountClass(): string
-    {
-        /** @var class-string<BaseInterface> $accountClass */
-        $accountClass = match (true) {
-            $this->odooVersion <= 17 => AccountV17::class,
-            $this->odooVersion <= 18 => AccountV18::class,
-            default => AccountV19::class,
-        };
-
-        return $accountClass;
-    }
-
-    /**
-     * Get the appropriate Uom class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getUomClass(): string
-    {
-        /** @var class-string<BaseInterface> $uomClass */
-        $uomClass = match (true) {
-            $this->odooVersion <= 17 => UomV17::class,
-            $this->odooVersion <= 18 => UomV18::class,
-            default => UomV19::class,
-        };
-
-        return $uomClass;
-    }
-
-    /**
-     * Get the appropriate Category class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getCategoryClass(): string
-    {
-        /** @var class-string<BaseInterface> $categoryClass */
-        $categoryClass = match (true) {
-            $this->odooVersion <= 17 => CategoryV17::class,
-            $this->odooVersion <= 18 => CategoryV18::class,
-            default => CategoryV19::class,
-        };
-
-        return $categoryClass;
-    }
-
-    /**
-     * Get the appropriate Move class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getMoveClass(): string
-    {
-        /** @var class-string<BaseInterface> $moveClass */
-        $moveClass = match (true) {
-            $this->odooVersion <= 17 => MoveV17::class,
-            $this->odooVersion <= 18 => MoveV18::class,
-            default => MoveV19::class,
-        };
-
-        return $moveClass;
-    }
-
-    /**
-     * Get the appropriate Journal class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getJournalClass(): string
-    {
-        /** @var class-string<BaseInterface> $journalClass */
-        $journalClass = match (true) {
-            $this->odooVersion <= 17 => JournalV17::class,
-            $this->odooVersion <= 18 => JournalV18::class,
-            default => JournalV19::class,
-        };
-
-        return $journalClass;
-    }
-
-    /**
-     * Get the appropriate Currency class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getCurrencyClass(): string
-    {
-        /** @var class-string<BaseInterface> $currencyClass */
-        $currencyClass = match (true) {
-            $this->odooVersion <= 17 => CurrencyV17::class,
-            $this->odooVersion <= 18 => CurrencyV18::class,
-            default => CurrencyV19::class,
-        };
-
-        return $currencyClass;
-    }
-
-    /**
-     * Get the appropriate Product class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getProductClass(): string
-    {
-        /** @var class-string<BaseInterface> $productClass */
-        $productClass = match (true) {
-            $this->odooVersion <= 17 => ProductV17::class,
-            $this->odooVersion <= 18 => ProductV18::class,
-            default => ProductV19::class,
-        };
-
-        return $productClass;
-    }
-
-    /**
-     * Get the appropriate Tax class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getTaxClass(): string
-    {
-        /** @var class-string<BaseInterface> $taxClass */
-        $taxClass = match (true) {
-            $this->odooVersion <= 17 => TaxV17::class,
-            $this->odooVersion <= 18 => TaxV18::class,
-            default => TaxV19::class,
-        };
-
-        return $taxClass;
-    }
-
-    /**
-     * Get the appropriate Method class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getMethodClass(): string
-    {
-        /** @var class-string<BaseInterface> $methodClass */
-        $methodClass = match (true) {
-            $this->odooVersion <= 17 => MethodV17::class,
-            $this->odooVersion <= 18 => MethodV18::class,
-            default => MethodV19::class,
-        };
-
-        return $methodClass;
-    }
-
-    /**
-     * Get the appropriate Payment class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getPaymentClass(): string
-    {
-        /** @var class-string<BaseInterface> $paymentClass */
-        $paymentClass = match (true) {
-            $this->odooVersion <= 17 => PaymentV17::class,
-            $this->odooVersion <= 18 => PaymentV18::class,
-            default => PaymentV19::class,
-        };
-
-        return $paymentClass;
-    }
-
-    /**
-     * Get the appropriate Template class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    public function getTemplateClass(): string
-    {
-        /** @var class-string<BaseInterface> $templateClass */
-        $templateClass = match (true) {
-            $this->odooVersion <= 17 => TemplateV17::class,
-            $this->odooVersion <= 18 => TemplateV18::class,
-            default => TemplateV19::class,
-        };
-
-        return $templateClass;
-    }
-
-    /**
-     * Get the appropriate Line class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    public function getLineClass(): string
-    {
-        /** @var class-string<BaseInterface> $lineClass */
-        $lineClass = match (true) {
-            $this->odooVersion <= 17 => LineV17::class,
-            $this->odooVersion <= 18 => LineV18::class,
-            default => LineV19::class,
-        };
-
-        return $lineClass;
-    }
-
-    /**
-     * Get the appropriate Register class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getRegisterClass(): string
-    {
-        /** @var class-string<BaseInterface> $registerClass */
-        $registerClass = match (true) {
-            $this->odooVersion <= 17 => RegisterV17::class,
-            $this->odooVersion <= 18 => RegisterV18::class,
-            default => RegisterV19::class,
-        };
-
-        return $registerClass;
+        return $this->odooVersion;
     }
 
     public function testManageProduct(): void
@@ -555,7 +296,7 @@ class ModelManagerTest extends TestCase
 
         $moveClass = $this->getMoveClass();
         $journalClass = $this->getJournalClass();
-        $methodClass = $this->getMethodClass();
+        $methodClass = $this->getPaymentMethodClass();
 
         // 1 - Retrieve the move to pay
         $searchDomains = new SearchDomains();

--- a/tests/Manager/ModelManagerTest.php
+++ b/tests/Manager/ModelManagerTest.php
@@ -64,8 +64,8 @@ class ModelManagerTest extends TestCase
 
     public function testManageProduct(): void
     {
-        $accountClass = $this->getAccountClass();
-        $partnerClass = $this->getPartnerClass();
+        $accountClass = $this->getAccountAccountClass();
+        $partnerClass = $this->getResPartnerClass();
 
         $searchDomains1 = new SearchDomains();
         $searchDomains1->addCriterion(Criterion::equal('code', '411100'));
@@ -109,7 +109,7 @@ class ModelManagerTest extends TestCase
 
     private function retrieveUom(string $name): BaseInterface
     {
-        $uomClass = $this->getUomClass();
+        $uomClass = $this->getUomUomClass();
         $searchDomains = new SearchDomains();
         $searchDomains->addCriterion(Criterion::equal('name', $name));
 
@@ -125,7 +125,7 @@ class ModelManagerTest extends TestCase
 
     private function retrieveFirstCategory(): BaseInterface
     {
-        $categoryClass = $this->getCategoryClass();
+        $categoryClass = $this->getProductCategoryClass();
         $category = $this->modelListManager->findOneBy($categoryClass);
 
         self::assertNotNull($category, 'Please create at least one category in ODOO !');
@@ -138,7 +138,7 @@ class ModelManagerTest extends TestCase
         $uom = $this->retrieveUom('Units');
         $category = $this->retrieveFirstCategory();
 
-        $templateClass = $this->getTemplateClass();
+        $templateClass = $this->getProductTemplateClass();
 
         // Use versioned classes based on Odoo version
         $template = match (true) {
@@ -188,11 +188,11 @@ class ModelManagerTest extends TestCase
         // 1 - retrieve the Company
         $companyId = 1;
 
-        $partnerClass = $this->getPartnerClass();
-        $journalClass = $this->getJournalClass();
-        $currencyClass = $this->getCurrencyClass();
-        $productClass = $this->getProductClass();
-        $taxClass = $this->getTaxClass();
+        $partnerClass = $this->getResPartnerClass();
+        $journalClass = $this->getAccountJournalClass();
+        $currencyClass = $this->getResCurrencyClass();
+        $productClass = $this->getProductProductClass();
+        $taxClass = $this->getAccountTaxClass();
 
         // 2 - retrieve a Partner
         $partner = $this->modelListManager->findOneBy($partnerClass);
@@ -294,9 +294,9 @@ class ModelManagerTest extends TestCase
         // 0 - retrieve the Company
         $companyId = 1;
 
-        $moveClass = $this->getMoveClass();
-        $journalClass = $this->getJournalClass();
-        $methodClass = $this->getPaymentMethodClass();
+        $moveClass = $this->getAccountMoveClass();
+        $journalClass = $this->getAccountJournalClass();
+        $methodClass = $this->getAccountPaymentMethodClass();
 
         // 1 - Retrieve the move to pay
         $searchDomains = new SearchDomains();
@@ -356,7 +356,7 @@ class ModelManagerTest extends TestCase
             $arguments
         );
 
-        $paymentClass = $this->getPaymentClass();
+        $paymentClass = $this->getAccountPaymentClass();
         self::assertIsArray($data);
         self::assertArrayHasKey('res_model', $data);
         self::assertEquals($paymentClass::getOdooModelName(), $data['res_model']);
@@ -373,7 +373,7 @@ class ModelManagerTest extends TestCase
         $journalRel = new OdooRelation($journalId);
         $currencyRel = new OdooRelation($currencyId);
 
-        $moveClass = $this->getMoveClass();
+        $moveClass = $this->getAccountMoveClass();
 
         return new $moveClass(
             $date,
@@ -390,7 +390,7 @@ class ModelManagerTest extends TestCase
         $emptyMoveRel = new OdooRelation();
         $currencyRel = new OdooRelation($currencyId);
 
-        $lineClass = $this->getLineClass();
+        $lineClass = $this->getAccountMoveLineClass();
 
         return new $lineClass($emptyMoveRel, $currencyRel, 'product');
     }
@@ -402,7 +402,7 @@ class ModelManagerTest extends TestCase
     ): BaseInterface {
         $journalRel = new OdooRelation($journal->getId());
 
-        $registerClass = $this->getRegisterClass();
+        $registerClass = $this->getAccountPaymentRegisterClass();
 
         self::assertTrue(method_exists($paymentMethod, 'getCode'));
         $paymentRegister = new $registerClass($date);
@@ -415,7 +415,7 @@ class ModelManagerTest extends TestCase
 
     private function createPartner(OdooRelation $payableRel, OdooRelation $receivableRel): BaseInterface
     {
-        $partnerClass = $this->getPartnerClass();
+        $partnerClass = $this->getResPartnerClass();
 
         return match (true) {
             $this->odooVersion <= 17 => new $partnerClass(

--- a/tests/Manager/ModelManagerTest.php
+++ b/tests/Manager/ModelManagerTest.php
@@ -21,9 +21,9 @@ use FluxSE\OdooApiClient\Operations\Object\ExecuteKw\RecordOperations;
 use FluxSE\OdooApiClient\Operations\Object\ExecuteKw\RecordOperationsInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Tests\FluxSE\OdooApiClient\OdooVersionedClassProviderTrait;
 use Tests\FluxSE\OdooApiClient\Operations\CommonOperationsTrait;
 use Tests\FluxSE\OdooApiClient\Operations\Object\ExecuteKw\ExecuteKwOperationsTrait;
-use Tests\FluxSE\OdooApiClient\TestModel\OdooVersionedClassProviderTrait;
 
 class ModelManagerTest extends TestCase
 {

--- a/tests/OdooVersionedClassProviderTrait.php
+++ b/tests/OdooVersionedClassProviderTrait.php
@@ -167,4 +167,3 @@ trait OdooVersionedClassProviderTrait
         };
     }
 }
-

--- a/tests/OdooVersionedClassProviderTrait.php
+++ b/tests/OdooVersionedClassProviderTrait.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\OdooApiClient;
+
+use FluxSE\OdooApiClient\Model\BaseInterface;
+use Tests\FluxSE\OdooApiClient\TestModel\V17\Object as V17;
+use Tests\FluxSE\OdooApiClient\TestModel\V18\Object as V18;
+use Tests\FluxSE\OdooApiClient\TestModel\V19\Object as V19;
+
+trait OdooVersionedClassProviderTrait
+{
+    abstract protected function getOdooVersion(): int;
+
+    /** @return class-string<BaseInterface> */
+    protected function getPartnerClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Res\Partner::class,
+            18 => V18\Res\Partner::class,
+            default => V19\Res\Partner::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getAccountClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Account\Account::class,
+            18 => V18\Account\Account::class,
+            default => V19\Account\Account::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getUomClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Uom\Uom::class,
+            18 => V18\Uom\Uom::class,
+            default => V19\Uom\Uom::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getCategoryClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Product\Category::class,
+            18 => V18\Product\Category::class,
+            default => V19\Product\Category::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getMoveClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Account\Move::class,
+            18 => V18\Account\Move::class,
+            default => V19\Account\Move::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getJournalClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Account\Journal::class,
+            18 => V18\Account\Journal::class,
+            default => V19\Account\Journal::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getCurrencyClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Res\Currency::class,
+            18 => V18\Res\Currency::class,
+            default => V19\Res\Currency::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getProductClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Product\Product::class,
+            18 => V18\Product\Product::class,
+            default => V19\Product\Product::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getTaxClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Account\Tax::class,
+            18 => V18\Account\Tax::class,
+            default => V19\Account\Tax::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getPaymentMethodClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Account\Payment\Method::class,
+            18 => V18\Account\Payment\Method::class,
+            default => V19\Account\Payment\Method::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getPaymentClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Account\Payment::class,
+            18 => V18\Account\Payment::class,
+            default => V19\Account\Payment::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getTemplateClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Product\Template::class,
+            18 => V18\Product\Template::class,
+            default => V19\Product\Template::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getLineClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Account\Move\Line::class,
+            18 => V18\Account\Move\Line::class,
+            default => V19\Account\Move\Line::class,
+        };
+    }
+
+    /** @return class-string<BaseInterface> */
+    protected function getRegisterClass(): string
+    {
+        /** @var class-string<BaseInterface> */
+        return match ($this->getOdooVersion()) {
+            17 => V17\Account\Payment\Register::class,
+            18 => V18\Account\Payment\Register::class,
+            default => V19\Account\Payment\Register::class,
+        };
+    }
+}
+

--- a/tests/OdooVersionedClassProviderTrait.php
+++ b/tests/OdooVersionedClassProviderTrait.php
@@ -14,156 +14,198 @@ trait OdooVersionedClassProviderTrait
     abstract protected function getOdooVersion(): int;
 
     /** @return class-string<BaseInterface> */
-    protected function getPartnerClass(): string
+    protected function getResPartnerClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Res\Partner::class,
             18 => V18\Res\Partner::class,
-            default => V19\Res\Partner::class,
+            19 => V19\Res\Partner::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "res.partner" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getAccountClass(): string
+    protected function getAccountAccountClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Account\Account::class,
             18 => V18\Account\Account::class,
-            default => V19\Account\Account::class,
+            19 => V19\Account\Account::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "account.account" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getUomClass(): string
+    protected function getUomUomClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Uom\Uom::class,
             18 => V18\Uom\Uom::class,
-            default => V19\Uom\Uom::class,
+            19 => V19\Uom\Uom::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "uom.uom" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getCategoryClass(): string
+    protected function getProductCategoryClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Product\Category::class,
             18 => V18\Product\Category::class,
-            default => V19\Product\Category::class,
+            19 => V19\Product\Category::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "product.category" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getMoveClass(): string
+    protected function getAccountMoveClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Account\Move::class,
             18 => V18\Account\Move::class,
-            default => V19\Account\Move::class,
+            19 => V19\Account\Move::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "account.move" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getJournalClass(): string
+    protected function getAccountJournalClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Account\Journal::class,
             18 => V18\Account\Journal::class,
-            default => V19\Account\Journal::class,
+            19 => V19\Account\Journal::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "account.journal" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getCurrencyClass(): string
+    protected function getResCurrencyClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Res\Currency::class,
             18 => V18\Res\Currency::class,
-            default => V19\Res\Currency::class,
+            19 => V19\Res\Currency::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "res.currency" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getProductClass(): string
+    protected function getProductProductClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Product\Product::class,
             18 => V18\Product\Product::class,
-            default => V19\Product\Product::class,
+            19 => V19\Product\Product::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "product.product" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getTaxClass(): string
+    protected function getAccountTaxClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Account\Tax::class,
             18 => V18\Account\Tax::class,
-            default => V19\Account\Tax::class,
+            19 => V19\Account\Tax::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "account.tax" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getPaymentMethodClass(): string
+    protected function getAccountPaymentMethodClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Account\Payment\Method::class,
             18 => V18\Account\Payment\Method::class,
-            default => V19\Account\Payment\Method::class,
+            19 => V19\Account\Payment\Method::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "account.payment.method" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getPaymentClass(): string
+    protected function getAccountPaymentClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Account\Payment::class,
             18 => V18\Account\Payment::class,
-            default => V19\Account\Payment::class,
+            19 => V19\Account\Payment::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "account.payment" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getTemplateClass(): string
+    protected function getProductTemplateClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Product\Template::class,
             18 => V18\Product\Template::class,
-            default => V19\Product\Template::class,
+            19 => V19\Product\Template::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "product.template" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getLineClass(): string
+    protected function getAccountMoveLineClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Account\Move\Line::class,
             18 => V18\Account\Move\Line::class,
-            default => V19\Account\Move\Line::class,
+            19 => V19\Account\Move\Line::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "account.move.line" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 
     /** @return class-string<BaseInterface> */
-    protected function getRegisterClass(): string
+    protected function getAccountPaymentRegisterClass(): string
     {
         /** @var class-string<BaseInterface> */
         return match ($this->getOdooVersion()) {
             17 => V17\Account\Payment\Register::class,
             18 => V18\Account\Payment\Register::class,
-            default => V19\Account\Payment\Register::class,
+            19 => V19\Account\Payment\Register::class,
+            default => throw new \InvalidArgumentException(
+                sprintf('No "account.payment.register" class available for Odoo version %d', $this->getOdooVersion())
+            ),
         };
     }
 }

--- a/tests/Provider/ModelFieldsProviderTest.php
+++ b/tests/Provider/ModelFieldsProviderTest.php
@@ -33,7 +33,7 @@ class ModelFieldsProviderTest extends TestCase
 
     public function testAccountMoveFields(): void
     {
-        $moveClass = $this->getMoveClass();
+        $moveClass = $this->getAccountMoveClass();
         $fields = $this->modelFieldsProvider->provide($moveClass, []);
 
         self::assertArrayNotHasKey('needed_terms', $fields);
@@ -42,7 +42,7 @@ class ModelFieldsProviderTest extends TestCase
 
     public function testResPartnerFields(): void
     {
-        $partnerClass = $this->getPartnerClass();
+        $partnerClass = $this->getResPartnerClass();
         $fields = $this->modelFieldsProvider->provide($partnerClass, []);
 
         self::assertContains('id', $fields);

--- a/tests/Provider/ModelFieldsProviderTest.php
+++ b/tests/Provider/ModelFieldsProviderTest.php
@@ -6,9 +6,9 @@ namespace Tests\FluxSE\OdooApiClient\Provider;
 
 use FluxSE\OdooApiClient\Provider\ModelFieldsProviderInterface;
 use PHPUnit\Framework\TestCase;
+use Tests\FluxSE\OdooApiClient\OdooVersionedClassProviderTrait;
 use Tests\FluxSE\OdooApiClient\Operations\CommonOperationsTrait;
 use Tests\FluxSE\OdooApiClient\Operations\Object\ExecuteKw\ExecuteKwOperationsTrait;
-use Tests\FluxSE\OdooApiClient\TestModel\OdooVersionedClassProviderTrait;
 
 class ModelFieldsProviderTest extends TestCase
 {

--- a/tests/Provider/ModelFieldsProviderTest.php
+++ b/tests/Provider/ModelFieldsProviderTest.php
@@ -1,23 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\FluxSE\OdooApiClient\Provider;
 
-use FluxSE\OdooApiClient\Model\BaseInterface;
 use FluxSE\OdooApiClient\Provider\ModelFieldsProviderInterface;
 use PHPUnit\Framework\TestCase;
 use Tests\FluxSE\OdooApiClient\Operations\CommonOperationsTrait;
 use Tests\FluxSE\OdooApiClient\Operations\Object\ExecuteKw\ExecuteKwOperationsTrait;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Account\Move as MoveV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Res\Partner as PartnerV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Account\Move as MoveV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Res\Partner as PartnerV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Account\Move as MoveV19;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Res\Partner as PartnerV19;
+use Tests\FluxSE\OdooApiClient\TestModel\OdooVersionedClassProviderTrait;
 
 class ModelFieldsProviderTest extends TestCase
 {
     use ExecuteKwOperationsTrait,
-        CommonOperationsTrait;
+        CommonOperationsTrait,
+        OdooVersionedClassProviderTrait;
 
     protected ModelFieldsProviderInterface $modelFieldsProvider;
 
@@ -29,36 +26,9 @@ class ModelFieldsProviderTest extends TestCase
         $this->odooVersion = $this->buildCommonOperations()->version()->getServerVersionInfo()[0];
     }
 
-    /**
-     * Get the appropriate Move class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getMoveClass(): string
+    protected function getOdooVersion(): int
     {
-        /** @var class-string<BaseInterface> $moveClass */
-        $moveClass = match (true) {
-            $this->odooVersion <= 17 => MoveV17::class,
-            $this->odooVersion <= 18 => MoveV18::class,
-            default => MoveV19::class,
-        };
-
-        return $moveClass;
-    }
-
-    /**
-     * Get the appropriate Partner class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getPartnerClass(): string
-    {
-        /** @var class-string<BaseInterface> $partnerClass */
-        $partnerClass = match (true) {
-            $this->odooVersion <= 17 => PartnerV17::class,
-            $this->odooVersion <= 18 => PartnerV18::class,
-            default => PartnerV19::class,
-        };
-
-        return $partnerClass;
+        return $this->odooVersion;
     }
 
     public function testAccountMoveFields(): void

--- a/tests/Serializer/OdooNormalizerTest.php
+++ b/tests/Serializer/OdooNormalizerTest.php
@@ -164,7 +164,7 @@ class OdooNormalizerTest extends TestCase
 
     private function createPartner(OdooRelation $payableRel, OdooRelation $receivableRel): BaseInterface
     {
-        $partnerClass = $this->getPartnerClass();
+        $partnerClass = $this->getResPartnerClass();
         $reflexion = new \ReflectionClass($partnerClass);
         $constructor = $reflexion->getConstructor();
         self::assertNotNull($constructor);

--- a/tests/Serializer/OdooNormalizerTest.php
+++ b/tests/Serializer/OdooNormalizerTest.php
@@ -10,9 +10,9 @@ use FluxSE\OdooApiClient\Serializer\Factory\SerializerFactory;
 use FluxSE\OdooApiClient\Serializer\OdooRelationsNormalizer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Serializer;
+use Tests\FluxSE\OdooApiClient\OdooVersionedClassProviderTrait;
 use Tests\FluxSE\OdooApiClient\Operations\CommonOperationsTrait;
 use Tests\FluxSE\OdooApiClient\Serializer\Model\Foo;
-use Tests\FluxSE\OdooApiClient\TestModel\OdooVersionedClassProviderTrait;
 
 class OdooNormalizerTest extends TestCase
 {

--- a/tests/Serializer/OdooNormalizerTest.php
+++ b/tests/Serializer/OdooNormalizerTest.php
@@ -12,13 +12,13 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Serializer;
 use Tests\FluxSE\OdooApiClient\Operations\CommonOperationsTrait;
 use Tests\FluxSE\OdooApiClient\Serializer\Model\Foo;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Res\Partner as PartnerV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Res\Partner as PartnerV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Res\Partner as PartnerV19;
+use Tests\FluxSE\OdooApiClient\TestModel\OdooVersionedClassProviderTrait;
 
 class OdooNormalizerTest extends TestCase
 {
-    use CommonOperationsTrait;
+    use CommonOperationsTrait,
+        OdooVersionedClassProviderTrait;
+
     private Serializer $serializer;
 
     private int $odooVersion;
@@ -30,20 +30,9 @@ class OdooNormalizerTest extends TestCase
         $this->odooVersion = $this->buildCommonOperations()->version()->getServerVersionInfo()[0];
     }
 
-    /**
-     * Get the appropriate Partner class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getPartnerClass(): string
+    protected function getOdooVersion(): int
     {
-        /** @var class-string<BaseInterface> $partnerClass */
-        $partnerClass = match ($this->odooVersion) {
-            17 => PartnerV17::class,
-            18 => PartnerV18::class,
-            default => PartnerV19::class,
-        };
-
-        return $partnerClass;
+        return $this->odooVersion;
     }
 
     public function testNormalizeForUpdate(): void

--- a/tests/Serializer/OdooRelationsNormalizerTest.php
+++ b/tests/Serializer/OdooRelationsNormalizerTest.php
@@ -91,7 +91,7 @@ class OdooRelationsNormalizerTest extends TestCase
 
     private function createLineWithTax(): BaseInterface
     {
-        $lineClass = $this->getLineClass();
+        $lineClass = $this->getAccountMoveLineClass();
         $line = new $lineClass(new OdooRelation(false), new OdooRelation(false), '');
         self::assertTrue(method_exists($line, 'addTaxIds'));
         $line->addTaxIds(new OdooRelation(10));

--- a/tests/Serializer/OdooRelationsNormalizerTest.php
+++ b/tests/Serializer/OdooRelationsNormalizerTest.php
@@ -10,8 +10,8 @@ use FluxSE\OdooApiClient\Serializer\Factory\SerializerFactory;
 use FluxSE\OdooApiClient\Serializer\OdooRelationsNormalizer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Serializer;
+use Tests\FluxSE\OdooApiClient\OdooVersionedClassProviderTrait;
 use Tests\FluxSE\OdooApiClient\Operations\CommonOperationsTrait;
-use Tests\FluxSE\OdooApiClient\TestModel\OdooVersionedClassProviderTrait;
 
 class OdooRelationsNormalizerTest extends TestCase
 {

--- a/tests/Serializer/OdooRelationsNormalizerTest.php
+++ b/tests/Serializer/OdooRelationsNormalizerTest.php
@@ -11,13 +11,12 @@ use FluxSE\OdooApiClient\Serializer\OdooRelationsNormalizer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Serializer;
 use Tests\FluxSE\OdooApiClient\Operations\CommonOperationsTrait;
-use Tests\FluxSE\OdooApiClient\TestModel\V17\Object\Account\Move\Line as LineV17;
-use Tests\FluxSE\OdooApiClient\TestModel\V18\Object\Account\Move\Line as LineV18;
-use Tests\FluxSE\OdooApiClient\TestModel\V19\Object\Account\Move\Line as LineV19;
+use Tests\FluxSE\OdooApiClient\TestModel\OdooVersionedClassProviderTrait;
 
 class OdooRelationsNormalizerTest extends TestCase
 {
-    use CommonOperationsTrait;
+    use CommonOperationsTrait,
+        OdooVersionedClassProviderTrait;
 
     private Serializer $serializer;
 
@@ -30,20 +29,9 @@ class OdooRelationsNormalizerTest extends TestCase
         $this->odooVersion = $this->buildCommonOperations()->version()->getServerVersionInfo()[0];
     }
 
-    /**
-     * Get the appropriate Line class based on Odoo version
-     * @return class-string<BaseInterface>
-     */
-    private function getLineClass(): string
+    protected function getOdooVersion(): int
     {
-        /** @var class-string<BaseInterface> $lineClass */
-        $lineClass = match (true) {
-            $this->odooVersion <= 17 => LineV17::class,
-            $this->odooVersion <= 18 => LineV18::class,
-            default => LineV19::class,
-        };
-
-        return $lineClass;
+        return $this->odooVersion;
     }
 
     public function testNormalize(): void


### PR DESCRIPTION
## Refactor: Extract versioned class providers into reusable trait

### Summary

This PR introduces a new `OdooVersionedClassProviderTrait` to centralize and standardize the version-specific model class resolution logic across all test files.

### Changes

- **New trait**: `tests/OdooVersionedClassProviderTrait.php`
  - Provides reusable methods for resolving versioned model classes (Partner, Account, Move, Journal, Currency, Product, Tax, Payment, Template, Line, Register, etc.)
  - Uses a clean `match` expression based on Odoo version (17, 18, or 19+)
  - Requires implementing classes to provide `getOdooVersion(): int`

- **Refactored test files**:
  - `ModelListManagerTest.php` - Replaced local `getPartnerClass()` with trait
  - `ModelManagerTest.php` - Removed ~220 lines of duplicated version resolution methods
  - `ModelFieldsProviderTest.php` - Replaced local `getMoveClass()` and `getPartnerClass()` with trait
  - `OdooNormalizerTest.php` - Replaced local `getPartnerClass()` with trait
  - `OdooRelationsNormalizerTest.php` - Replaced local `getLineClass()` with trait

### Benefits

- **DRY principle**: Eliminates significant code duplication across test files
- **Maintainability**: Adding support for new Odoo versions now requires changes in only one place
- **Consistency**: All tests use the same version resolution logic
- **Cleaner imports**: Uses namespace aliases (`V17`, `V18`, `V19`) for better readability
