### PR TITLE
fix: support string ID in OdooRelationDenormalizer

### DIFF
--- a/src/Serializer/OdooRelationDenormalizer.php
+++ b/src/Serializer/OdooRelationDenormalizer.php
@@ -48,7 +48,7 @@ final class OdooRelationDenormalizer implements DenormalizerInterface
             throw new InvalidArgumentException('The data must be an array!');
         }
 
-        /** @var int|false|null $id */
+        /** @var int|string|false|null $id */
         $id = $data[0] ?? null;
         if ($id === null || false === is_numeric($id)) {
             throw new InvalidArgumentException(
@@ -59,6 +59,6 @@ final class OdooRelationDenormalizer implements DenormalizerInterface
         /** @var string|false|null $displayName */
         $displayName = $data[1] ?? null;
         $displayName = false === $displayName ? null : (string) $displayName; // Something false is returned by the API
-        return new OdooRelation($id, $displayName);
+        return new OdooRelation((int) $id, $displayName);
     }
 }

--- a/tests/Serializer/OdooRelationDenormalizerTest.php
+++ b/tests/Serializer/OdooRelationDenormalizerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\OdooApiClient\Serializer;
+
+use FluxSE\OdooApiClient\Model\OdooRelation;
+use FluxSE\OdooApiClient\Serializer\Factory\SerializerFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Serializer;
+
+class OdooRelationDenormalizerTest extends TestCase
+{
+    private Serializer $serializer;
+
+    protected function setUp(): void
+    {
+        $serializerFactory = new SerializerFactory();
+        $this->serializer = $serializerFactory->create();
+    }
+
+    public function testDenormalizeWithIntId(): void
+    {
+        /** @var OdooRelation $relation */
+        $relation = $this->serializer->denormalize([123, 'Test Name'], OdooRelation::class);
+
+        self::assertInstanceOf(OdooRelation::class, $relation);
+        self::assertEquals(123, $relation->getId());
+        self::assertEquals('Test Name', $relation->getDisplayName());
+    }
+
+    public function testDenormalizeWithStringId(): void
+    {
+        /** @var OdooRelation $relation */
+        $relation = $this->serializer->denormalize(['456', 'Test Name'], OdooRelation::class);
+
+        self::assertInstanceOf(OdooRelation::class, $relation);
+        self::assertEquals(456, $relation->getId());
+        self::assertEquals('Test Name', $relation->getDisplayName());
+    }
+
+    public function testDenormalizeWithIdOnly(): void
+    {
+        /** @var OdooRelation $relation */
+        $relation = $this->serializer->denormalize([789, 'Test Name'], OdooRelation::class);
+
+        self::assertInstanceOf(OdooRelation::class, $relation);
+        self::assertEquals(789, $relation->getId());
+        self::assertEquals('Test Name', $relation->getDisplayName());
+    }
+
+    public function testDenormalizeWithEmptyDisplayName(): void
+    {
+        /** @var OdooRelation $relation */
+        $relation = $this->serializer->denormalize([321, ''], OdooRelation::class);
+
+        self::assertInstanceOf(OdooRelation::class, $relation);
+        self::assertEquals(321, $relation->getId());
+        self::assertEquals('', $relation->getDisplayName());
+    }
+
+    public function testDenormalizeWithFalseDisplayName(): void
+    {
+        /** @var OdooRelation $relation */
+        $relation = $this->serializer->denormalize([123, false], OdooRelation::class);
+
+        self::assertInstanceOf(OdooRelation::class, $relation);
+        self::assertEquals(123, $relation->getId());
+        self::assertNull($relation->getDisplayName());
+    }
+
+    public function testDenormalizeWithInvalidId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The first element of the $data array must be an integer value!');
+
+        $this->serializer->denormalize(['not-a-number', 'Test Name'], OdooRelation::class);
+    }
+
+    public function testDenormalizeWithNullId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The first element of the $data array must be an integer value!');
+
+        $this->serializer->denormalize([null, 'Test Name'], OdooRelation::class);
+    }
+
+    public function testDenormalizeWithFalseId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The first element of the $data array must be an integer value!');
+
+        $this->serializer->denormalize([false, 'Test Name'], OdooRelation::class);
+    }
+}


### PR DESCRIPTION
## Description

The Odoo API is not always consistent and can sometimes return an ID as a string instead of an integer.

## Changes

- Add `string` type to the `$id` variable annotation in `OdooRelationDenormalizer`
- Cast `$id` to `int` before passing it to the `OdooRelation` constructor
- Add `OdooRelationDenormalizerTest` with comprehensive test cases

## Tests

- Standard integer ID
- String ID (the fixed case)
- ID with empty display_name
- display_name set to false
- Invalid ID (non-numeric) → exception
- Null ID → exception
- False ID → exception